### PR TITLE
fix(cmd/root): fix typo in console message for json output

### DIFF
--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -17,6 +17,6 @@ func init() {
 		&RootCmdFlagJson,
 		"json",
 		false,
-		"Formatu output to JSON",
+		"Format output to JSON",
 	)
 }


### PR DESCRIPTION
Fixes a super tiny typo. It bothers me every time I do something with JSON :)